### PR TITLE
Fix transport_name option error

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 /phpunit.xml.dist export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
+/Dockerfile export-ignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Simple image to install gearman extension for local testing
+FROM php:7.4-cli
+
+RUN apt-get update; \
+    apt-get install -y --no-install-recommends \
+        libgearman-dev \
+    ; \
+    pecl install \
+        gearman \
+    ; \
+    pecl clear-cache; \
+    docker-php-ext-enable \
+        gearman \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    apt-get clean

--- a/src/Transport/GearmanTransportFactory.php
+++ b/src/Transport/GearmanTransportFactory.php
@@ -10,6 +10,8 @@ class GearmanTransportFactory implements TransportFactoryInterface
 {
     public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
     {
+        unset($options['transport_name']);
+
         return new GearmanTransport(Connection::fromDsn($dsn, $options), $serializer);
     }
 

--- a/tests/Transport/ConnectionTest.php
+++ b/tests/Transport/ConnectionTest.php
@@ -7,6 +7,7 @@ use SD\Gearman\Transport\Connection;
 
 /**
  * @requires extension gearman >= 2.0
+ * @group integration
  */
 class ConnectionTest extends TestCase
 {

--- a/tests/Transport/GearmanTransportFactoryTest.php
+++ b/tests/Transport/GearmanTransportFactoryTest.php
@@ -8,6 +8,9 @@ use SD\Gearman\Transport\GearmanTransport;
 use SD\Gearman\Transport\GearmanTransportFactory;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
+/**
+ * @requires extension gearman >= 2.0
+ */
 class GearmanTransportFactoryTest extends TestCase
 {
     public function testSupportsOnlyGearmanTransports()
@@ -27,7 +30,8 @@ class GearmanTransportFactoryTest extends TestCase
         $serializer = $this->createMock(SerializerInterface::class);
         $expectedTransport = new GearmanTransport(Connection::fromDsn($dsn), $serializer);
 
-        $this->assertEquals($expectedTransport, $factory->createTransport($dsn, [], $serializer));
+        // transport_name is added by Messenger by default
+        $this->assertEquals($expectedTransport, $factory->createTransport($dsn, ['transport_name' => 'gearman'], $serializer));
     }
 
     public function testCreateTransportWithOptions()


### PR DESCRIPTION
Fixes the transport_name option passed by Messenger causing a validation error.